### PR TITLE
Default number of threads set to the number of cpu cores.

### DIFF
--- a/MPlayerX/PlayerController.m
+++ b/MPlayerX/PlayerController.m
@@ -111,7 +111,8 @@ enum {
 					   [NSNumber numberWithUnsignedInt:kSubFileNameRuleContain], kUDKeySubFileNameRule,
 					   boolNo, kUDKeyDTSPassThrough,
 					   boolNo, kUDKeyAC3PassThrough,
-					   [NSNumber numberWithUnsignedInt:2], kUDKeyThreadNum,
+					   // Set the default number of threads used by ffmpeg to the number of cpu cores present on the computer.
+					   [NSNumber numberWithUnsignedInt: [[NSProcessInfo processInfo] processorCount]], kUDKeyThreadNum,
 					   boolYes, kUDKeyUseEmbeddedFonts,
 					   [NSNumber numberWithUnsignedInt:10000], kUDKeyCacheSize,
 					   [NSNumber numberWithUnsignedInt:10000], kUDKeyCacheSizeLocal,


### PR DESCRIPTION
Set the default number of threads used by ffmpeg to the number of cpu cores present on the computer.
ie. My quad core imac will use 4 threads by default.
